### PR TITLE
DDF-346: Updated opensearch bundle reference to properly embed.

### DIFF
--- a/search-ui/search-endpoint/pom.xml
+++ b/search-ui/search-endpoint/pom.xml
@@ -110,7 +110,7 @@
                     <instructions>
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
-                            json-smart,ddf.catalog.opensearch,bayeux-api,cometd-java-common,cometd-java-server,jackson-mapper-asl,jackson-core-asl,catalog-core-api-impl
+                            json-smart,catalog-opensearch-endpoint,bayeux-api,cometd-java-common,cometd-java-server,jackson-mapper-asl,jackson-core-asl,catalog-core-api-impl
                         </Embed-Dependency>
                         <Spring-Context>*;wait-for-dependencies:=true;timeout:=604800</Spring-Context>
                         <!-- Package uses conflict if we do not embed this -->


### PR DESCRIPTION
Simple fix to a mistake that I found while doing some testing. Just had to use the artifactId instead of the groupId in the Embed-Dependency declaration. 
