### PR TITLE
DDF-877 - Fixed an internal backbone-association's error caused by dot notation in json attribute names

### DIFF
--- a/search-ui/standard/src/main/webapp/js/ApplicationHelpers.js
+++ b/search-ui/standard/src/main/webapp/js/ApplicationHelpers.js
@@ -16,8 +16,22 @@
 define([
     'backbone',
     'q',
-    'underscore'
+    'underscore',
+    'backboneassociations'
 ],function (Backbone, Q, _) {
+
+
+
+    // Backbone associations uses "." as its standard sub-object selecting within their framework.  However
+    // since some of our json attribute names have "." characters in the name, this causes associations to do undesired
+    // sub-object querying when we do simple set operations on models model.set("my.attribute.name","foo").
+    // If we ever want utilize this pathing, we need to use "~" instead so we don't conflicts with the pathing functionality.
+    //
+    // if someone wants to use the Backbone.Association sub-object selecting, they can do model.get('object~subObject~deeperSubObject');
+    //
+    // This sub object selecting can be see at http://dhruvaray.github.io/backbone-associations/specify-associations.html#sa-getsetop
+    Backbone.Associations.SEPARATOR = '~';
+
     /**
      * A very simple promise wrapper of fetch that just resolves or rejects.  Warning! If
      * you define a success or error handler in options, this will overwrite them for now.


### PR DESCRIPTION
-json output containing attribute names with "." in their names were causing issues with the "_getAttr" method in Backbone.Associations.  When dot notation is used with a Model.set() or a Model.get(), it tries to do sub-object path based on the dot notation used (which is not what we want)
-Changing the Backbone.Associations.SEPARATOR from "." (the default) to "~" fixes the issue.  Sub-Selecting can still be done, but you will need to use the ~ character instead.
-The subObject pathing can be explained at http://dhruvaray.github.io/backbone-associations/specify-associations.html#sa-getsetop
