### PR TITLE
DDF-886 - Added number support for the Query builder.

### DIFF
--- a/search-ui/standard/src/main/webapp/js/controllers/Filter.controller.js
+++ b/search-ui/standard/src/main/webapp/js/controllers/Filter.controller.js
@@ -93,9 +93,16 @@ define([
                         _.each(pairs, function(pair){
                             if(!_.contains(currentFieldNames, pair[0])){
                                 // doesn't exist.  lets add.
+
+                                var fieldType = pair[1].toLowerCase();
+                                // lets convert to a number type.
+                                if(_.contains(Properties.filters.numberTypes, fieldType)){
+                                    fieldType = 'number';
+                                }
+
                                 var fieldObj = {
                                     name: pair[0],
-                                    type: pair[1].toLowerCase()
+                                    type: fieldType
                                 };
                                 array.push(fieldObj);
                             }

--- a/search-ui/standard/src/main/webapp/js/model/CQL.factory.js
+++ b/search-ui/standard/src/main/webapp/js/model/CQL.factory.js
@@ -37,8 +37,10 @@ define([
                 case 'string':
                     if(moment(value).isValid()){
                         return moment(value).format(Properties.CQL_DATE_FORMAT);
+                    } else {
+                        return "'" + value.replace(/'/g, "''") + "'";
                     }
-                    return "'" + value.replace(/'/g, "''") + "'";
+                    break;
                 case 'number':
                     return String(value);
                 case 'object':
@@ -96,22 +98,22 @@ define([
         },
         number: {
             '=': function (filter) {
-                throw new Error("Not implemented yet." + filter);
+                return Filter.CQLFactory.formatFieldName(filter.get('fieldName')) + ' = ' + filter.get('numberValue1');
             },
-            '!=': function (filter) {
-                throw new Error("Not implemented yet." + filter);
+            '!=': function () {
+                throw new Error("!= is not supported for this filter.");
             },
             '>': function (filter) {
-                throw new Error("Not implemented yet." + filter);
+                return Filter.CQLFactory.formatFieldName(filter.get('fieldName')) + ' > ' + filter.get('numberValue1');
             },
             '>=': function (filter) {
-                throw new Error("Not implemented yet." + filter);
+                return Filter.CQLFactory.formatFieldName(filter.get('fieldName')) + ' >= ' + filter.get('numberValue1');
             },
             '<': function (filter) {
-                throw new Error("Not implemented yet." + filter);
+                return Filter.CQLFactory.formatFieldName(filter.get('fieldName')) + ' < ' + filter.get('numberValue1');
             },
             '<=': function (filter) {
-                throw new Error("Not implemented yet." + filter);
+                return Filter.CQLFactory.formatFieldName(filter.get('fieldName')) + ' <= ' + filter.get('numberValue1');
             }
         },
         anyGeo: {

--- a/search-ui/standard/src/main/webapp/properties.js
+++ b/search-ui/standard/src/main/webapp/properties.js
@@ -34,9 +34,10 @@ define(function (require) {
                 'string': ['contains','equals'],
                 'xml': ['contains','equals'],
                 'date': ['before','after'],
-                'number': ['=','!=','>','>=','<','<='],
+                'number': ['=','>','>=','<','<='],
                 'anyGeo': ['intersects']
-            }
+            },
+            numberTypes : ['float','short', 'long','double', 'integer']
         },
 
         init : function(){


### PR DESCRIPTION
-adjusted the filter controller to handle different types numeric types
that come back from the search results.  Any java number type found will
be converted to the "number" filter type.  This saves alot of boilerplate
code and we can handle numbers in a generic way.
-removed != from the number operator list.  Its not supported on the
backend yet, so I left a placeholder for when its supported.
