### PR TITLE
DDF-906 - Adjusted initial query to always selected all content types by default

### DIFF
--- a/search-ui/standard/src/main/webapp/js/model/Metacard.js
+++ b/search-ui/standard/src/main/webapp/js/model/Metacard.js
@@ -224,7 +224,7 @@ define([
                 return _.map(geometries, function (geometry) {
                     return new MetaCard.Geometry(geometry);
                 });
-            },
+            }
 
         });
 

--- a/search-ui/standard/src/main/webapp/js/model/Query.js
+++ b/search-ui/standard/src/main/webapp/js/model/Query.js
@@ -19,9 +19,10 @@ define([
         'js/model/Metacard',
         'usngs',
         'js/model/Filter',
+        'wreqr',
         'backboneassociations'
     ],
-    function (Backbone, _, properties, moment, Metacard, usngs, Filter) {
+    function (Backbone, _, properties, moment, Metacard, usngs, Filter,wreqr) {
         "use strict";
         var Query = {};
 
@@ -175,17 +176,6 @@ define([
                     }));
                 }
 
-                // type
-                var types = this.get('type');
-                if (types) {
-                    filters.push(new Filter.Model({
-                        fieldName: properties.filters.METADATA_CONTENT_TYPE,
-                        fieldType: 'string',
-                        fieldOperator: 'contains',
-                        stringValue1: types  // this should already be common delimited for us.
-                    }));
-                }
-
                 // spacial stuff.
                 var north = this.get('north'),
                     south = this.get('south'),
@@ -234,6 +224,28 @@ define([
                         fieldType: 'string',
                         fieldOperator: 'contains',
                         stringValue1: '*'
+                    }));
+                }
+
+                // type
+                var types = this.get('type');
+                if (types) {
+                    filters.push(new Filter.Model({
+                        fieldName: properties.filters.METADATA_CONTENT_TYPE,
+                        fieldType: 'string',
+                        fieldOperator: 'contains',
+                        stringValue1: types  // this should already be common delimited for us.
+                    }));
+                } else {
+                    // fill in all content types and the no value type.
+                    var contentTypes = wreqr.reqres.request('workspace:gettypes');
+                    var allTypes = contentTypes.pluck('name');
+                    allTypes.push('no-value');
+                    filters.push(new Filter.Model({
+                        fieldName: properties.filters.METADATA_CONTENT_TYPE,
+                        fieldType: 'string',
+                        fieldOperator: 'contains',
+                        stringValue1: allTypes.join(',')
                     }));
                 }
 


### PR DESCRIPTION
-Adjusted ToFilters to build a full content-type filter based on the content-types.  Also adds in the no-value field as well to complete the query.
-Removed the es5 from the jshint.  This will warn us about code that may not working in older browsers.
