### PR TITLE
DDF-939 - Completed implementation of optional banners in search ui

### DIFF
--- a/search-ui/standard/src/main/webapp/less/styles.less
+++ b/search-ui/standard/src/main/webapp/less/styles.less
@@ -3,3 +3,9 @@
 @import "util.less";
 @import "components/init.less";
 
+// override for cesium draw helper.
+// when in draw mode, this tooltip will still appear.
+.twipsy {
+  display: none;
+}
+

--- a/search-ui/standard/src/main/webapp/main.js
+++ b/search-ui/standard/src/main/webapp/main.js
@@ -39,10 +39,10 @@ define(['config'], function () {
         //remove this code when the correct way to get the div to resize is discovered
         $(window).resize(function () {
             var height = $('body').height();
-            if (properties.header && properties.header !== '') {
+            if (properties.ui.header && properties.ui.header !== '') {
                 height = height - 20;
             }
-            if (properties.footer && properties.footer !== '') {
+            if (properties.ui.footer && properties.ui.footer !== '') {
                 height = height - 20;
             }
             $('#content').height(height);

--- a/search-ui/standard/src/main/webapp/properties.js
+++ b/search-ui/standard/src/main/webapp/properties.js
@@ -25,6 +25,8 @@ define(function (require) {
 
         CQL_DATE_FORMAT : 'YYYY-MM-DD[T]HH:mm:ss[Z]',
 
+        ui: {},
+
         filters: {
             METADATA_CONTENT_TYPE: 'metadata-content-type',
             SOURCE_ID: 'source-id',
@@ -50,10 +52,24 @@ define(function (require) {
                 url: "/services/store/config"
             }).success(function(data) {
                     props = _.extend(props, data);
+
+                $.ajax({
+                    async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+                    cache: false,
+                    dataType: 'json',
+                    url: "/services/platform/config/ui"
+                }).success(function(uiConfig){
+                    props.ui = uiConfig;
                     return props;
-                }).fail(function(jqXHR, status, errorThrown) {
-                    throw new Error('Configuration could not be loaded: (status: ' + status + ', message: ' + errorThrown.message + ')');
+                }).fail(function(jqXHR, status, errorThrown){
+                    if(console){
+                        console.log('Platform UI Configuration could not be loaded: (status: ' + status + ', message: ' + errorThrown.message + ')');
+                    }
                 });
+
+            }).fail(function(jqXHR, status, errorThrown) {
+                throw new Error('Configuration could not be loaded: (status: ' + status + ', message: ' + errorThrown.message + ')');
+            });
 
             return props;
         }

--- a/search-ui/standard/src/main/webapp/templates/filter/facet.item.handlebars
+++ b/search-ui/standard/src/main/webapp/templates/filter/facet.item.handlebars
@@ -26,7 +26,7 @@
 
                 <div class="pull-left" title="{{value}}">
                     {{#is value "no-value"}}
-                        No Value
+                        (no value)
                     {{else}}
                         {{value}}
                     {{/is}}

--- a/search-ui/standard/src/main/webapp/templates/footer.layout.handlebars
+++ b/search-ui/standard/src/main/webapp/templates/footer.layout.handlebars
@@ -13,8 +13,8 @@
  --}}
 <div class="footer-container">
     <div class="banner-container">
-        <div class="{{style}} {{textColor}}">
-            {{footer}}
+        <div style="color: {{ui.color}}; background-color: {{ui.background}}">
+            {{ui.footer}}
         </div>
     </div>
 </div>

--- a/search-ui/standard/src/main/webapp/templates/header.layout.handlebars
+++ b/search-ui/standard/src/main/webapp/templates/header.layout.handlebars
@@ -13,8 +13,8 @@
  --}}
 <div class="header-container">
     <div class="banner-container">
-        <div class="{{style}} {{textColor}}">
-            {{header}}
+        <div style="color: {{ui.color}}; background-color: {{ui.background}}">
+            {{ui.header}}
         </div>
     </div>
 </div>

--- a/search-ui/standard/src/test/resources/ui.json
+++ b/search-ui/standard/src/test/resources/ui.json
@@ -1,0 +1,6 @@
+{
+  "footer": "UNCLASSIFIED",
+  "color": "white",
+  "background": "green",
+  "header": "UNCLASSIFIED"
+}

--- a/search-ui/standard/test.js
+++ b/search-ui/standard/test.js
@@ -30,6 +30,7 @@ app.use(express.static(__dirname + '/src/main/webapp'));
 console.log('setting up mock query endpoint');
 app.all('/services/catalog/sources', server.mockRequest);
 app.all('/services/store/config', server.mockRequest);
+app.all('/services/platform/config/ui', server.mockRequest);
 app.all('/services/user', server.mockRequest);
 app.all('/cometd/handshake', server.mockRequest);
 app.all('/cometd/connect', server.mockCometD);


### PR DESCRIPTION
-Hooked in new Platform UI configurations into the search ui.
-added extra ajax call for the ui configurations.
-noticed drawhelper.js was using twipsy and was overlayed over my footer.  Displaying it by default fixes it and it will appears when you are in draw mode (good news).
-added ui config to the test config (fixed tests i broke during this
ticket)
-changes no-value option to "(no value)" as requested.
