### PR TITLE
DDF-1017: 2.6.x toggled the setting of the user login on the search page to show the login by default

### DIFF
--- a/search-ui/standard/src/main/java/org/codice/ddf/ui/searchui/standard/properties/ConfigurationStore.java
+++ b/search-ui/standard/src/main/java/org/codice/ddf/ui/searchui/standard/properties/ConfigurationStore.java
@@ -76,7 +76,7 @@ public class ConfigurationStore {
 
     private String terrainEndpoint;
 
-    private Boolean isSignIn = false;
+    private Boolean isSignIn = true;
 
     private Boolean isTask = false;
 

--- a/search-ui/standard/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/search-ui/standard/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -37,7 +37,7 @@
             required="false" type="Integer" default="5000" />
 
         <AD description="Allow Sign In to Search UI and welcome notice. Enable this if the Search UI is protected." name="Show Sign In" id="signIn"
-            required="false" type="Boolean" default="false" />
+            required="false" type="Boolean" default="true" />
 
         <AD description="Show task menu area for long running actions." name="Show Tasks" id="task"
             required="false" type="Boolean" default="false" />


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-ui/42)

<!-- Reviewable:end -->
