### PR TITLE
DDF-1079: In the Catalog Federation Strategy dialog, it is necessary to disable ca...

### DIFF
--- a/search-ui/search-endpoint/pom.xml
+++ b/search-ui/search-endpoint/pom.xml
@@ -114,7 +114,11 @@
             <artifactId>gt-cql</artifactId>
             <version>8.4</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>17.0</version>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
@@ -152,7 +156,8 @@
                             jackson-mapper-asl,
                             jackson-core-asl,
                             joda-time,
-                            json-smart
+                            json-smart,
+                            guava
                         </Embed-Dependency>
                         <Web-ContextPath>/search/cometd</Web-ContextPath>
                         <Spring-Context>*;wait-for-dependencies:=true;timeout:=604800</Spring-Context>

--- a/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
+++ b/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
@@ -177,8 +177,18 @@ public class SearchController {
                     QueryResponse indexResponse = executeQuery(sourceId, request,
                             subject, properties);
 
+                    // query updated cache
+                    properties.put("mode", "cache");
+                    QueryResponse cachedResponse = executeQuery(null, request,
+                            subject, properties);
+
                     try {
-                        Search search = addQueryResponseToSearch(request, indexResponse);
+                        Search search;
+                        if (cachedResponse.getHits() == 0) {
+                            search = addQueryResponseToSearch(request, indexResponse);
+                        }else{
+                            search = addQueryResponseToSearch(request, cachedResponse);
+                        }
                         search.updateStatus(sourceId, indexResponse);
                         pushResults(request.getId(),
                                     controller.transform(search, request),

--- a/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
+++ b/search-ui/search-endpoint/src/main/java/org/codice/ddf/ui/searchui/query/controller/SearchController.java
@@ -177,13 +177,8 @@ public class SearchController {
                     QueryResponse indexResponse = executeQuery(sourceId, request,
                             subject, properties);
 
-                    // query updated cache
-                    properties.put("mode", "cache");
-                    QueryResponse cachedResponse = executeQuery(null, request,
-                            subject, properties);
-
                     try {
-                        Search search = addQueryResponseToSearch(request, cachedResponse);
+                        Search search = addQueryResponseToSearch(request, indexResponse);
                         search.updateStatus(sourceId, indexResponse);
                         pushResults(request.getId(),
                                     controller.transform(search, request),


### PR DESCRIPTION
...ching of products as a workaround to the problem described in https://tools.codice.org/jira/browse/DDF-1029.

This solution involves reverting to the following changes:
https://github.com/codice/ddf-catalog/commit/873f7c74520fc097bf764a1e9554046de8904b71

In addition, more logic is required in the CachingFederationStrategy.java to guard against adding of records to the metacard cache when caching is disabled.

The ddf-ui SearchController.java class will also require an update to expect all results from a single 'index' mode in lieu of separately querying a 'cache' mode. When caching is enabled, all results are returned when querying 'index' mode.

These changes were tested using by reproducing the issue documented in DDF-1029 with caching enabled, and disabled. When disabled the problem documented in the DDF-1029 was not reproduced, but when enabled the problem was reproduced. The ability to use the existing catalog interfaces were also tested with caching enabled and disabled to ensure that the changes to the CachingFederationStrategy didn't introduce any errors. 
