### PR TITLE
DDF-1178 Split property names on camel case and all non-word characters

### DIFF
--- a/search-ui/standard/bower.json
+++ b/search-ui/standard/bower.json
@@ -19,7 +19,7 @@
     "jquery-cookie": "1.4.1",
     "jquery-ui": "1.10.4",
     "jqueryui-timepicker-addon": "v1.4.5",
-    "lodash": "2.4.1",
+    "lodash": "3.7.0",
     "marionette": "2.4.1",
     "moment": "2.5.1",
     "multiselect": "ehynds/jquery-ui-multiselect-widget#2489720d3b06cf52025d5b7bbd3187ea15a8253f",

--- a/search-ui/standard/src/main/webapp/js/HandlebarsHelpers.js
+++ b/search-ui/standard/src/main/webapp/js/HandlebarsHelpers.js
@@ -294,15 +294,15 @@ define([
                 }
             },
             propertyTitle: function (str) {
-                if(str && typeof str === "string") {
-                    return str.split("-").join(" ").replace(/\w\S*/g, function (word) {
-                        return word.charAt(0).toUpperCase() + word.substr(1);
-                    });
+                if (_.isString(str)) {
+                    return _.chain(str).words().map(function(word) {
+                        return _.capitalize(word);
+                    }).join(' ');
                 }
                 return str;
             },
             safeString: function (str) {
-                if(str && typeof str === "string") {
+                if (_.isString(str)) {
                     return new Handlebars.SafeString(str);
                 }
                 return str;
@@ -311,7 +311,7 @@ define([
                 return str.split('-').join(' ');
             },
             encodeString: function (str) {
-                if(str && typeof str === "string") {
+                if (_.isString(str)) {
                     return encodeURIComponent(str);
                 }
                 return str;

--- a/search-ui/standard/src/main/webapp/main.js
+++ b/search-ui/standard/src/main/webapp/main.js
@@ -32,8 +32,7 @@ require.config({
         backbonecometd: 'lib/backbone-cometd/backbone.cometd.extension',
         backboneundo: 'lib/Backbone.Undo.js/Backbone.Undo',
         poller: 'lib/backbone-poller/backbone.poller',
-        underscore: 'lib/lodash/dist/lodash.underscore.min',
-        lodash: 'lib/lodash/dist/lodash.min',
+        underscore: 'lib/lodash/lodash.min',
         marionette: 'lib/marionette/lib/backbone.marionette.min',
         // TODO test combining
         modelbinder: 'lib/backbone.modelbinder/Backbone.ModelBinder.min',
@@ -165,7 +164,8 @@ require.onError = function (err) {
     }
 };
 
-require(['jquery',
+require(['underscore',
+        'jquery',
         'backbone',
         'marionette',
         'application',
@@ -173,8 +173,16 @@ require(['jquery',
         'properties',
         'js/HandlebarsHelpers',
         'js/ApplicationHelpers'],
-    function ($, Backbone, Marionette, app, ich, properties) {
+    function (_, $, Backbone, Marionette, app, ich, properties) {
         'use strict';
+
+        // Make lodash compatible with Backbone
+        var lodash = _.noConflict();
+        _.mixin({
+            'debounce': _.debounce || lodash.debounce,
+            'defer': _.defer || lodash.defer,
+            'pluck': _.pluck || lodash.pluck
+        });
 
         var document = window.document;
 


### PR DESCRIPTION
Adds support to split property names on all non-\w characters.  It also now splits on camel case words.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-ui/68)

<!-- Reviewable:end -->
