### PR TITLE
DDF-1253 Updating the geo location search menu to be more stable

### DIFF
--- a/search-ui/standard/src/main/webapp/js/view/Query.view.js
+++ b/search-ui/standard/src/main/webapp/js/view/Query.view.js
@@ -170,8 +170,12 @@ define([
                     lat: undefined,
                     lon: undefined,
                     radius: undefined,
-                    bbox: undefined
+                    bbox: undefined,
+                    polygon: undefined,
+                    usng: undefined,
+                    usngbb: undefined
                 }, {unset: true});
+                wreqr.vent.trigger("search:drawstop");
                 wreqr.vent.trigger("search:drawend");
                 this.updateScrollbar();
             },
@@ -443,16 +447,21 @@ define([
             beforeShowDatePicker: function(picker){
                 picker.style.zIndex = 200;
             },
-
+            notDrawing: function(){
+                this.clearLocation();
+            },
             drawCircle: function(){
+                this.clearLocation();
                 wreqr.vent.trigger("search:drawcircle", this.model);
             },
 
             drawPolygon: function(){
+                this.clearLocation();
                 wreqr.vent.trigger("search:drawpoly", this.model);
             },
 
             drawBbox: function(){
+                this.clearLocation();
                 wreqr.vent.trigger("search:drawbbox", this.model);
             },
 


### PR DESCRIPTION
- Query.view.js:
  - Updated the "clearLocation" method to properly clear out the previous geo data and to properly stop the drawing.
  - Added a "notDrawing" method to hook into the "any" geo button.  It calls "clearLocation" so previous drawings and geo data are properly cleared.
  - Updated "drawCircle", "drawPolygon", and "drawBbox" to call "clearLocation" so that previous drawings and geo data can be properly cleared.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-ui/87)

<!-- Reviewable:end -->
