### PR TITLE
DDF-1293 Increased timeout from 30 seconds to 60 seconds

### DIFF
--- a/search-ui/standard/src/test/resources/config.json
+++ b/search-ui/standard/src/test/resources/config.json
@@ -1,6 +1,6 @@
 {
   "branding": "DDF",
-  "timeout": 30000,
+  "timeout": 60000,
   "resultCount": 250,
   "gazetteer": false,
   "projection": "EPSG:4326",


### PR DESCRIPTION
Increased timeout so that Jenkins builds won't fail

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codice/ddf-ui/93)

<!-- Reviewable:end -->
